### PR TITLE
refactor(dist): Improve structure and allow skipping deb generation

### DIFF
--- a/.github/workflows/pr-trailers.yml
+++ b/.github/workflows/pr-trailers.yml
@@ -9,10 +9,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  git_trailers:
+  git-trailers:
     name: Add Git Trailers to PR commits
-    if: ${{ github.event.review.state == 'approved' }}
+    if: ${{ github.event.pull_request.base.ref == 'main' && github.event.review.state == 'approved' }}
     uses: nubificus/vaccel/.github/workflows/add-git-trailers.yml@main
-    with:
-      plugin: 'scripts'
     secrets: inherit

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -12,26 +12,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  validate_files_and_commits:
+  validate-files-and-commits:
     name: Validate Files and Commits
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     uses: nubificus/vaccel/.github/workflows/validate-files-and-commits.yml@main
-    with:
-      plugin: 'scripts'
     secrets: inherit
 
-  validate_code:
+  validate-code:
     name: Validate Code
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     uses: ./.github/workflows/validate-code.yml
-    with:
-      plugin: 'scripts'
     secrets: inherit
 
   # Dummy job for setting required checks
-  jobs_completed:
-    needs: [validate_files_and_commits, validate_code]
+  jobs-completed:
+    needs: [validate-files-and-commits, validate-code]
     name: Jobs Completed
-    runs-on: self-hosted
+    runs-on: gcc-2204-amd64
     steps:
       - run: exit 0

--- a/.github/workflows/validate-code.yml
+++ b/.github/workflows/validate-code.yml
@@ -3,18 +3,24 @@ name: Validate Source Code
 on:
   workflow_call:
     inputs:
+      actions-repo:
+        type: string
+        default: 'nubificus/vaccel'
+      actions-rev:
+        type: string
+        default: 'main'
       runner:
         type: string
-        default: '["gcc", "lite", "2204"]'
-      runner-arch:
+        default: '["gcc", "dind", "2204"]'
+      runner-archs:
         type: string
-        default: 'x86_64'
+        default: '["amd64"]'
+      runner-arch-map:
+        type: string
+        default: '[{"amd64":"x86_64", "arm64":"aarch64", "arm":"armv7l"}]'
       options:
         type: string
         default: 'auto_features=enabled'
-      plugin:
-        type: string
-        default: ''
     secrets:
       GIT_CLONE_PAT:
         required: false
@@ -23,30 +29,34 @@ on:
       AWS_SECRET_ACCESS_KEY:
         required: false
 
-jobs:
-  linter_super_linter:
-    name: Lint Python/Shell/GHActions/Markdown/YAML/JS
-    runs-on: [self-hosted, x86_64, "${{ fromJSON(inputs.runner) }}"]
+env:
+  ACTIONS_REV: ${{ (github.repository != inputs.actions-repo) && inputs.actions-rev || '' }}
 
+jobs:
+  linter-super-linter:
+    name: Lint Python/Shell/GHActions/Markdown/YAML/JS
+    runs-on: ${{ format('{0}-{1}', join(fromJSON(inputs.runner), '-'), matrix.arch) }}
+    strategy:
+      matrix:
+        arch: ["${{ fromJSON(inputs.runner-archs) }}"]
+      fail-fast: false
     permissions:
       contents: read
       packages: read
       statuses: write
-
     steps:
       - name: Checkout .github directory
         uses: actions/checkout@v4
         with:
           sparse-checkout: .github
-          repository: ${{ (inputs.plugin != '' && 'nubificus/vaccel') || '' }}
-          ref: ${{ (inputs.plugin != '' && 'main') || '' }}
+          repository: ${{ inputs.actions-repo }}
+          ref: ${{ env.ACTIONS_REV }}
 
       - name: Initialize workspace
-        id: initialize_workspace
         uses: ./.github/actions/initialize-workspace
         with:
           fetch-depth: 0
-          remote-actions-repo: ${{ (inputs.plugin != '' && 'nubificus/vaccel') || '' }}
+          remote-actions-repo: ${{ inputs.actions-repo }}
           token: ${{ secrets.GIT_CLONE_PAT || github.token }}
 
       - name: Run super-linter

--- a/dist.sh
+++ b/dist.sh
@@ -3,143 +3,264 @@
 
 set -e
 
-# generate .version file
-SCRIPTS_DIR=$(cd -- "$(dirname -- "$0")" >/dev/null && pwd -P)
-cd "${MESON_SOURCE_ROOT}" || exit 1
-VERSION="$(sh "${SCRIPTS_DIR}"/generate-version.sh "" --no-dirty)"
-echo "${VERSION}" >"${MESON_DIST_ROOT}/.version"
-
-# parse script args
-PKG_NAME=$1 && shift
-PKG_BUILDTYPE=$1 && shift
-MESON_ARGS="--buildtype=${PKG_BUILDTYPE} "
-c=$((0))
-for v in "$@"; do
-	if [ $((c % 2)) -eq 0 ]; then
-		MESON_ARGS="${MESON_ARGS}-D$v="
-	else
-		MESON_ARGS="${MESON_ARGS}$v "
-	fi
-	c=$((c + 1))
-done
+SCRIPT_NAME=$(basename "$0")
 REPO_URL=$(git remote get-url origin |
 	sed 's/git@github.com:\(.*\)\.git/https:\/\/github.com\/\1/g')
-NOT_VACCEL=0
-if [ "${PKG_NAME}" != "vaccel" ]; then
-	[ "${PKG_NAME#*"vaccel"}" = "${PKG_NAME}" ] && exit 1
-	NOT_VACCEL=1
-fi
-printf "Package    : %s\n" "${PKG_NAME}"
-printf "Version    : %s\n" "${VERSION}"
-printf "Build type : %s\n" "${PKG_BUILDTYPE}"
-printf "Repo URL   : %s\n" "${REPO_URL}"
-printf "Meson args : %s\n\n" "${MESON_ARGS}"
-
-cd "${MESON_DIST_ROOT}" || exit 1
-
-# generate binary dist
-# (needs: meson dist --include-subprojects)
-printf "%s\n\n" "Generating binary distribution"
-BIN_NAME="${PKG_NAME}-${VERSION}"
-BIN_TAR_NAME="${BIN_NAME}-bin.tar.gz"
-BIN_PREFIX="${MESON_DIST_ROOT}/build/${BIN_NAME}"
-rm -rf ../"${BIN_TAR_NAME}" build
-eval meson setup "${MESON_ARGS}" \
-	--prefix="${BIN_PREFIX}/usr" \
-	build &&
-	meson compile -C build &&
-	meson install -C build &&
-	tar cfz ../"${BIN_TAR_NAME}" -C build "${BIN_NAME}"
-rm -rf build
-printf "\n%s\n\n" "Created $(dirname "${MESON_DIST_ROOT}")/${BIN_TAR_NAME}"
-
-# generate .deb packages
-# (needs: meson dist --include-subprojects)
-printf "%s\n\n" "Generating deb package"
-for p in "build-essential" "dh-make" "git-buildpackage"; do
-	if [ -z "$(dpkg -l | awk "/^ii  $p/")" ]; then
-		echo "Not building a deb package: Package $p missing"
-		return
-	fi
-done
-rm -f ../*"${VERSION}".orig.tar.xz
-rm -rf "${MESON_DIST_ROOT}"/.git*
-UPFULLNAME="Anastassios Nanos"
-UPEMAIL="ananos@nubificus.co.uk"
-DEBFULLNAME="Kostis Papazafeiropoulos"
+UPFULLNAME='Anastassios Nanos'
+UPEMAIL='ananos@nubificus.co.uk'
+DEBFULLNAME='Kostis Papazafeiropoulos'
 export DEBFULLNAME
-DEBEMAIL="papazof@nubificus.co.uk"
+DEBEMAIL='papazof@nubificus.co.uk'
 export DEBEMAIL
 
-USER="$(whoami)" \
-	dh_make -s -y -c apache -p "${PKG_NAME}_${VERSION}" --createorig
+log_error() {
+	error=${1:-'Unknown error'}
+	code=${2:-1}
+	echo "${SCRIPT_NAME}: ${error} [error ${code}]" >&2
+	unset error
+	unset code
+}
 
-# debian/rules
-printf "%s\n" "export DEB_LDFLAGS_MAINT_STRIP = -Wl,-Bsymbolic-functions" \
-	>>debian/rules
-printf "%s\n\t%s" "override_dh_auto_configure:" \
-	"dh_auto_configure --buildsystem=meson -- ${MESON_ARGS}" \
-	>>debian/rules
+error() {
+	error_code=${2:-1}
+	log_error "$1" "${error_code}"
+	exit "${error_code}"
+}
 
-# debian/copyright
-sed -i "s/Upstream-Contact.*/Upstream-Contact: ${UPFULLNAME} <${UPEMAIL}>/g" \
-	debian/copyright
-sed -i "s/Source.*/Source: $(echo "$REPO_URL" | sed 's/\//\\\//g')/g" \
-	debian/copyright
-sed -i -z -e "s/\(Copyright:\)\n[^\n]\+[\n]*[^\n]*\n\(License\)/\1 2020-$(date +"%Y") Nubificus LTD <info@nubificus.co.uk>\n\2/g" \
-	debian/copyright
-sed -i -z -e "s/\n#.*[\n]*//g" debian/copyright
+parse_args() {
+	short_opts='n:v:t:a:'
+	long_opts='pkg-name:,pkg-version:,build-type:,build-arg:,skip-deb'
 
-# debian/control
-sed -i "s/Homepage.*/Homepage: https:\/\/vaccel.org/g" debian/control
-sed -i "s/Section.*/Section: libs/g" debian/control
-sed -i -z -e "s/Description.*/Description: Hardware Acceleration for Serverless Computing/g" \
-	debian/control
-sed -i "/^#.*/d" debian/control
-sed -i "/cmake/d" debian/control
-if [ "${NOT_VACCEL}" = 1 ]; then
-	sed -i -z -e 's/\(Depends:\n.*\n\)\(Description\)/\1 vaccel,\n\2/g' \
+	if ! getopt=$(getopt -o "${short_opts}" --long "${long_opts}" \
+		-n "${SCRIPT_NAME}" -- "$@"); then
+		echo 'Failed to parse args' >&2
+		exit 1
+	fi
+
+	eval set -- "$getopt"
+
+	build_args=
+	skip_deb=0
+	while true; do
+		case "$1" in
+		'-n' | '--pkg-name')
+			# Package name
+			[ -z "$2" ] && error "'$1' requires a non-empty string"
+			pkg_name="$2"
+			shift 2
+			;;
+		'-v' | '--pkg-version')
+			# Package version
+			[ -z "$2" ] && error "'$1' requires a non-empty string"
+			pkg_version="$2"
+			shift 2
+			;;
+		'-t' | '--build-type')
+			# Build type
+			[ -z "$2" ] && error "'$1' requires a non-empty string"
+			build_type="$2"
+			shift 2
+			;;
+		'-a' | '--build-arg')
+			# Build args
+			arg=$(echo "$2" | cut -d'=' -f1)
+			value=$(echo "$2" | cut -d'=' -f2-)
+			[ -z "${arg}" ] || [ -z "${value}" ] &&
+				error "'$1' requires a string of the form 'arg=value'"
+			build_args="${build_args} -D${arg}=${value}"
+			unset arg
+			unset value
+			shift 2
+			;;
+		'--skip-deb')
+			# Skip deb generation
+			skip_deb=1
+			shift
+			;;
+		--)
+			shift
+			break
+			;;
+		*)
+			echo 'Internal error parsing args' >&2
+			exit 1
+			;;
+		esac
+	done
+	build_args="--buildtype=${build_type} ${build_args}"
+
+	if [ -z "${pkg_name}" ] || [ -z "${pkg_version}" ] ||
+		[ -z "${build_type}" ]; then
+		error 'Package name, version or buildtype was not provided'
+	fi
+}
+
+generate_version_file() {
+	echo "${pkg_version}" >"${MESON_DIST_ROOT}/.version"
+}
+
+is_vaccel() {
+	if [ "${pkg_name}" != "vaccel" ]; then
+		[ "${pkg_name#*"vaccel"}" = "${pkg_name}" ] && exit 1
+		return 1 # false
+	fi
+	return 0 # true
+}
+
+generate_bin_pkg() {
+	bin_name="${pkg_name}-${pkg_version}"
+	bin_tar_name="${bin_name}-bin.tar.gz"
+	bin_prefix="${MESON_DIST_ROOT}/build/${bin_name}"
+
+	rm -rf ../"${bin_tar_name}" build
+	eval meson setup "${build_args}" --prefix="${bin_prefix}/usr" build
+	meson compile -C build
+	meson install -C build
+	tar cfz ../"${bin_tar_name}" -C build "${bin_name}"
+	rm -rf build
+
+	printf "\n%s\n\n" \
+		"Created $(dirname "${MESON_DIST_ROOT}")/${bin_tar_name}"
+}
+
+deb_check_requirements() {
+	missing_pkgs=
+	for p in 'build-essential' 'dh-make' 'git-buildpackage'; do
+		if [ -z "$(dpkg -l | awk "/^ii  $p/")" ]; then
+			missing_pkgs="${missing_pkgs} $p"
+		fi
+	done
+	if [ -n "${missing_pkgs}" ]; then
+		echo "Not building a deb package: Packages ${missing_pkgs} missing"
+		return 1
+	fi
+	return 0
+}
+
+deb_process_rules() {
+	printf "%s\n" \
+		'export DEB_LDFLAGS_MAINT_STRIP = -Wl,-Bsymbolic-functions' \
+		>>debian/rules
+	printf "%s\n\t%s" 'override_dh_auto_configure:' \
+		"dh_auto_configure --buildsystem=meson -- ${build_args}" \
+		>>debian/rules
+}
+
+deb_process_copyright() {
+	sed -i "s/Upstream-Contact.*/Upstream-Contact: ${UPFULLNAME} <${UPEMAIL}>/g" \
+		debian/copyright
+	sed -i "s/Source.*/Source: $(echo "$REPO_URL" | sed 's/\//\\\//g')/g" \
+		debian/copyright
+	sed -i -z -e \
+		"s/\(Copyright:\)\n[^\n]\+[\n]*[^\n]*\n\(License\)/\1 2020-$(date +"%Y") Nubificus LTD <info@nubificus.co.uk>\n\2/g" \
+		debian/copyright
+	sed -i -z -e "s/\n#.*[\n]*//g" debian/copyright
+}
+
+deb_process_control() {
+	sed -i 's/Homepage.*/Homepage: https:\/\/vaccel.org/g' \
 		debian/control
-fi
+	sed -i 's/Section.*/Section: libs/g' debian/control
+	sed -i -z -e \
+		's/Description.*/Description: Hardware Acceleration for Serverless Computing/g' \
+		debian/control
+	sed -i '/^#.*/d' debian/control
+	sed -i '/cmake/d' debian/control
+	if ! is_vaccel; then
+		sed -i -z -e \
+			's/\(Depends:\n.*\n\)\(Description\)/\1 vaccel,\n\2/g' \
+			debian/control
+	fi
+}
 
-# debian/changelog
-echo "Generating changelog"
-sed -i "2d;3d" debian/changelog
-cp -r "${MESON_SOURCE_ROOT}"/.git* ./
-TAG=$(git describe --abbrev=0 --tags --match "v[0-9]*" 2>/dev/null)
-TAG_DIFF=$(git describe --abbrev=8 --tags --match "v[0-9]*" 2>/dev/null)
-ORIG_COMMIT=$(git rev-parse HEAD)
-for t in $(git tag --sort=v:refname | grep "v[0-9]*"); do
-	CUR_VERSION="$(echo "$t" | cut -c 2-)-1"
-	git checkout "$t" 1>/dev/null 2>&1
-	PREV_TAG=$(git describe --abbrev=0 --tags --match "v[0-9]*" \
-		--exclude="$t" 2>/dev/null) ||
-		PREV_TAG=$(git rev-list --max-parents=0 HEAD | tail -n 1)
-	gbp dch --since="${PREV_TAG}" --ignore-branch --release \
-		--spawn-editor=never --new-version="${CUR_VERSION}" \
-		--dch-opt="-b" --dch-opt="--check-dirname-level=0" \
-		--dch-opt="-p" \
-		--git-log="--invert-grep --grep=Signed-off-by:.*github-actions" \
-		1>/dev/null 2>&1
-done
-if [ "${TAG}" != "${TAG_DIFF}" ]; then
-	git checkout "${ORIG_COMMIT}" 1>/dev/null 2>&1
-	PREV_TAG=$(git describe --abbrev=0 --tags --match "v[0-9]*" \
-		2>/dev/null) ||
-		PREV_TAG=$(git rev-list --max-parents=0 HEAD | tail -n 1)
-	CUR_VERSION="${VERSION}-1"
-	gbp dch --since="${PREV_TAG}" --ignore-branch --release \
-		--spawn-editor=never --new-version="${CUR_VERSION}" \
-		--dch-opt="-b" --dch-opt="--check-dirname-level=0" \
-		--dch-opt="-p" \
-		--git-log="--invert-grep --grep=Signed-off-by:.*github-actions" \
-		1>/dev/null 2>&1
-fi
-rm -rf "${MESON_DIST_ROOT}"/.git*
+deb_changelog_add_commits() {
+	gbp dch --since="$1" --ignore-branch --release \
+		--spawn-editor=never --new-version="$2" \
+		--dch-opt='-b' --dch-opt='--check-dirname-level=0' \
+		--dch-opt='-p' \
+		--git-log='--invert-grep --grep=^Signed-off-by:.*github-actions --grep=^Signed-off-by:.*dependabot --grep=^ci: --grep=^ci(.*):'
+}
 
-echo "Building package"
-rm -rf debian/*.ex debian/*.EX debian/*.docs debian/README*
-dpkg-buildpackage -us -uc
-rm -rf obj-* debian
-printf "\n%s\n\n" \
-	"Created $(ls "$(dirname "${MESON_DIST_ROOT}")"/"${PKG_NAME}_${VERSION}"*.deb)"
+deb_process_changelog() {
+	sed -i '2d;3d' debian/changelog
+	tag=$(git describe --abbrev=0 --tags --match 'v[0-9]*' 2>/dev/null)
+	tag_diff=$(git describe --abbrev=8 --tags --match 'v[0-9]*' 2>/dev/null)
+	orig_commit=$(git rev-parse HEAD)
+	for t in $(git tag --sort=v:refname | grep 'v[0-9]*'); do
+		cur_version="$(echo "$t" | cut -c 2-)-1"
+		git checkout "$t" 1>/dev/null 2>&1
+		prev_tag=$(git describe --abbrev=0 --tags --match 'v[0-9]*' \
+			--exclude="$t" 2>/dev/null) ||
+			prev_tag=$(git rev-list --max-parents=0 HEAD | tail -n 1)
+		deb_changelog_add_commits "${prev_tag}" "${cur_version}"
+	done
+	if [ "${tag}" != "${tag_diff}" ]; then
+		git checkout "${orig_commit}" 1>/dev/null 2>&1
+		prev_tag=$(git describe --abbrev=0 --tags --match 'v[0-9]*' \
+			2>/dev/null) ||
+			prev_tag=$(git rev-list --max-parents=0 HEAD | tail -n 1)
+		cur_version="${pkg_version}-1"
+		deb_changelog_add_commits "${prev_tag}" "${cur_version}"
+	fi
+	unset tag
+	unset tag_diff
+	unset orig_commit
+}
+
+generate_deb_pkg() {
+	! deb_check_requirements && return 0
+
+	rm -f ../*"${pkg_version}".orig.tar.xz
+	rm -rf "${MESON_DIST_ROOT}"/.git*
+
+	USER="$(whoami)" \
+		dh_make -s -y -c apache \
+		-p "${pkg_name}_${pkg_version}" --createorig
+
+	# debian/rules
+	deb_process_rules
+
+	# debian/copyright
+	deb_process_copyright
+
+	# debian/control
+	deb_process_control
+
+	# debian/changelog
+	echo 'Generating changelog'
+	cp -r "${MESON_SOURCE_ROOT}"/.git* ./
+	deb_process_changelog
+	rm -rf "${MESON_DIST_ROOT}"/.git*
+
+	echo 'Building package'
+	rm -rf debian/*.ex debian/*.EX debian/*.docs debian/README*
+	dpkg-buildpackage -us -uc
+	rm -rf obj-* debian
+
+	printf "\n%s\n\n" \
+		"Created $(ls "$(dirname "${MESON_DIST_ROOT}")"/"${pkg_name}_${pkg_version}"*.deb)"
+}
+
+main() {
+	parse_args "$@"
+
+	printf "Package    : %s\n" "${pkg_name}"
+	printf "Version    : %s\n" "${pkg_version}"
+	printf "Repo URL   : %s\n" "${REPO_URL}"
+	printf "Build type : %s\n" "${build_type}"
+	printf "Meson args : %s\n\n" "${build_args}"
+
+	generate_version_file
+
+	cd "${MESON_DIST_ROOT}" || error "Could not change to ${MESON_DIST_ROOT}"
+
+	printf "%s\n\n" 'Generating binary distribution'
+	generate_bin_pkg
+
+	if [ "${skip_deb}" -eq 0 ]; then
+		printf "%s\n\n" 'Generating deb package'
+		generate_deb_pkg
+	fi
+}
+
+main "$@"


### PR DESCRIPTION
Improve `dist.sh` structure and allow skipping deb generation:
- Split code into functions
- Use `getopt` for passing/parsing script arguments
- Add option to skip deb generation
- Exclude ci/dependabot commits from deb changelog