### PR TITLE
refactor(generate-version): Do not fail if repo has no tags

### DIFF
--- a/generate-version.sh
+++ b/generate-version.sh
@@ -18,7 +18,7 @@ if [ ! -d "${SRC_DIR}/.git" ]; then
 	exit 1
 fi
 
-VERSION=$(git describe --abbrev=8 --tags --match "v[0-9]*" 2>/dev/null)
+VERSION=$(git describe --abbrev=8 --tags --match "v[0-9]*" 2>/dev/null || echo)
 
 if [ -z "${VERSION}" ]; then
 	SHA=$(git describe --abbrev=8 --always 2>/dev/null)


### PR DESCRIPTION
Do not fail to generate version if a repo has no tags