### PR TITLE
chore(config): Increase default max stack frame

### DIFF
--- a/config/variables.env
+++ b/config/variables.env
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_VALGRIND_ARGS="--leak-check=full --show-leak-kinds=all --track-origins=yes --errors-for-leak-kinds=all --max-stackframe=3150000 --keep-debuginfo=yes --error-exitcode=1"
+CONFIG_VALGRIND_ARGS="--leak-check=full --show-leak-kinds=all --track-origins=yes --errors-for-leak-kinds=all --max-stackframe=3160000 --keep-debuginfo=yes --error-exitcode=1"
 CONFIG_32_VALGRIND_EXTRA_ARGS="--sigill-diagnostics=no"
 CONFIG_32_VALGRIND_EXPORT_VARS="OPENSSL_armcap=0"
 CONFIG_VACCEL_LOG_LEVEL=4


### PR DESCRIPTION
Increase the default value of max stack frame for valgrind to handle more complex vAccel examples/tests