### PR TITLE
feat: Include arch in artifact names and improve versioning, packaging

### DIFF
--- a/_sh-common.sh
+++ b/_sh-common.sh
@@ -3,28 +3,7 @@
 
 set -e
 
-sh_print_arch() {
-	arch="$(uname -m | tr ' ' '_' | tr '/' '-')"
-	if [ "$(getconf LONG_BIT)" -eq 32 ]; then
-		arch="$(printf '%s' "${arch}" | sed 's/x86_64/i686/')"
-		arch="$(printf '%s' "${arch}" | sed 's/aarch64/armv7l/')"
-	fi
-	printf '%s\n' "${arch}"
-	unset arch
-}
-
-sh_log_error() {
-	error=${1:-'Unknown error'}
-	code=${2:-1}
-	printf "%s: %s [error %s]\n" \
-		"${SH_SCRIPT_NAME}" "${error}" "${code}" \
-		>&2
-	unset error
-	unset code
-}
-
-sh_error() {
-	error_code=${2:-1}
-	sh_log_error "$1" "${error_code}"
-	exit "${error_code}"
-}
+_SH_SCRIPTS_DIR="$(cd -- "$(dirname -- "$0")" >/dev/null && pwd -P)"
+SH_SCRIPTS_DIR="${SH_SCRIPTS_DIR:-"$_SH_SCRIPTS_DIR"}"
+# shellcheck source=/dev/null
+. "${SH_SCRIPTS_DIR}/sh-common.sh"

--- a/_sh-common.sh
+++ b/_sh-common.sh
@@ -3,6 +3,16 @@
 
 set -e
 
+sh_print_arch() {
+	arch="$(uname -m | tr ' ' '_' | tr '/' '-')"
+	if [ "$(getconf LONG_BIT)" -eq 32 ]; then
+		arch="$(printf '%s' "${arch}" | sed 's/x86_64/i686/')"
+		arch="$(printf '%s' "${arch}" | sed 's/aarch64/armv7l/')"
+	fi
+	printf '%s\n' "${arch}"
+	unset arch
+}
+
 sh_log_error() {
 	error=${1:-'Unknown error'}
 	code=${2:-1}

--- a/config/config-env.sh
+++ b/config/config-env.sh
@@ -136,6 +136,8 @@ _config_set_common_vars() {
 		CONFIG_ARCH_IS_64BIT=0
 	fi
 
+	CONFIG_ARCH="$(sh_print_arch)"
+
 	if [ "${CONFIG_USE_VALGRIND}" -eq 1 ]; then
 		_config_set_valgrind_cmd "${CONFIG_ARCH_IS_64BIT}"
 
@@ -195,6 +197,7 @@ _config_process_pkg_export_vars() {
 }
 
 _config_print_vars() {
+	printf "Arch               : %s\n" "${CONFIG_ARCH}"
 	printf "Arch is 64bit      : %s\n" \
 		"$(_config_bool_to_string "${CONFIG_ARCH_IS_64BIT}")"
 	printf "Default config dir : %s\n" "${CONFIG_DEF_CFG_DIR}"

--- a/config/config-env.sh
+++ b/config/config-env.sh
@@ -3,8 +3,8 @@
 
 set -e
 
-_CONFIG_DEF_CFG_DIR=$(cd -- "$(dirname -- "$0")" >/dev/null && pwd -P)
-CONFIG_DEF_CFG_DIR=${CONFIG_DEF_CFG_DIR:-"${_CONFIG_DEF_CFG_DIR}"}
+_CONFIG_DEF_CFG_DIR="$(cd -- "$(dirname -- "$0")" >/dev/null && pwd -P)"
+CONFIG_DEF_CFG_DIR="${CONFIG_DEF_CFG_DIR:-"${_CONFIG_DEF_CFG_DIR}"}"
 
 SH_SCRIPTS_DIR="${SH_SCRIPTS_DIR:-"${CONFIG_DEF_CFG_DIR}/.."}"
 # shellcheck source=/dev/null
@@ -13,6 +13,8 @@ SH_SCRIPTS_DIR="${SH_SCRIPTS_DIR:-"${CONFIG_DEF_CFG_DIR}/.."}"
 if [ -n "${CONFIG_PKG_SCRIPTS_DIR}" ]; then
 	CONFIG_PKG_CFG_DIR="${CONFIG_PKG_SCRIPTS_DIR}/config"
 fi
+
+CONFIG_USE_VALGRIND="${CONFIG_USE_VALGRIND:-0}"
 
 _config_bool_to_string() {
 	if [ "$1" -eq 1 ]; then

--- a/config/config-env.sh
+++ b/config/config-env.sh
@@ -6,11 +6,9 @@ set -e
 _CONFIG_DEF_CFG_DIR=$(cd -- "$(dirname -- "$0")" >/dev/null && pwd -P)
 CONFIG_DEF_CFG_DIR=${CONFIG_DEF_CFG_DIR:-"${_CONFIG_DEF_CFG_DIR}"}
 
-_SH_SCRIPTS_DIR="${CONFIG_DEF_CFG_DIR}/.."
-# shellcheck disable=SC2034
-SH_SCRIPT_NAME="$(basename "$0")"
+SH_SCRIPTS_DIR="${SH_SCRIPTS_DIR:-"${CONFIG_DEF_CFG_DIR}/.."}"
 # shellcheck source=/dev/null
-. "${_SH_SCRIPTS_DIR}/_sh-common.sh"
+. "${SH_SCRIPTS_DIR}/_sh-common.sh"
 
 if [ -n "${CONFIG_PKG_SCRIPTS_DIR}" ]; then
 	CONFIG_PKG_CFG_DIR="${CONFIG_PKG_SCRIPTS_DIR}/config"

--- a/dist-common.sh
+++ b/dist-common.sh
@@ -1,0 +1,297 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+_SH_SCRIPTS_DIR="$(cd -- "$(dirname -- "$0")" >/dev/null && pwd -P)"
+SH_SCRIPTS_DIR="${SH_SCRIPTS_DIR:-"$_SH_SCRIPTS_DIR"}"
+# shellcheck source=/dev/null
+. "${SH_SCRIPTS_DIR}/_sh-common.sh"
+
+DIST_REPO_URL=$(git remote get-url origin |
+	sed 's/git@github.com:\(.*\)\.git/https:\/\/github.com\/\1/g')
+_DIST_UPSTREAM_CONTACT='vaccel@nubificus.co.uk'
+_DIST_DEBFULLNAME='Kostis Papazafeiropoulos'
+_DIST_DEBEMAIL='papazof@nubificus.co.uk'
+
+parse_args() {
+	short_opts='n:v:t:a:'
+	long_opts='pkg-name:,pkg-version:,build-type:,build-arg:,pkg-config-path:'
+	long_opts="${long_opts},skip-subprojects,skip-deb,version-only"
+
+	if ! getopt=$(getopt -o "$short_opts" --long "$long_opts" \
+		-n "$SH_SCRIPT_NAME" -- "$@"); then
+		sh_error 'Failed to parse args'
+	fi
+
+	eval set -- "$getopt"
+
+	DIST_BUILD_ARGS=
+	DIST_INSTALL_ARGS=
+	DIST_SKIP_DEB=0
+	DIST_SKIP_SUBPROJECTS=0
+	DIST_VERSION_ONLY=0
+	while true; do
+		case "$1" in
+		'-n' | '--pkg-name')
+			# Package name
+			[ -z "$2" ] &&
+				sh_error "'$1' requires a non-empty string"
+			DIST_PKG_NAME="$2"
+			shift 2
+			;;
+		'-v' | '--pkg-version')
+			# Package version
+			[ -z "$2" ] &&
+				sh_error "'$1' requires a non-empty string"
+			DIST_PKG_VERSION="$2"
+			shift 2
+			;;
+		'-t' | '--build-type')
+			# Build type
+			[ -z "$2" ] &&
+				sh_error "'$1' requires a non-empty string"
+			DIST_BUILD_TYPE="$2"
+			shift 2
+			;;
+		'-a' | '--build-arg')
+			# Build args
+			arg=$(echo "$2" | cut -d'=' -f1)
+			value=$(echo "$2" | cut -d'=' -f2-)
+			[ -z "${arg}" ] || [ -z "${value}" ] &&
+				sh_error "'$1' requires a string of the form 'arg=value'"
+			DIST_BUILD_ARGS="${DIST_BUILD_ARGS} -D${arg}=${value}"
+			unset arg
+			unset value
+			shift 2
+			;;
+		'--pkg-config-path')
+			# Pkg-config path
+			if [ -n "$2" ]; then
+				arg="--pkg-config-path=${2}"
+				DIST_BUILD_ARGS="${DIST_BUILD_ARGS} ${arg}"
+				unset arg
+			fi
+			shift 2
+			;;
+		'--skip-subprojects')
+			# Skip subproject installation
+			DIST_SKIP_SUBPROJECTS=1
+			shift
+			;;
+		'--skip-deb')
+			# Skip deb generation
+			# shellcheck disable=SC2034
+			DIST_SKIP_DEB=1
+			shift
+			;;
+		'--version-only')
+			# Only generate version file
+			# shellcheck disable=SC2034
+			DIST_VERSION_ONLY=1
+			shift
+			;;
+		--)
+			shift
+			break
+			;;
+		*)
+			sh_error 'Internal error parsing args'
+			;;
+		esac
+	done
+
+	DIST_BUILD_ARGS="--buildtype=${DIST_BUILD_TYPE} ${DIST_BUILD_ARGS}"
+	[ "${DIST_SKIP_SUBPROJECTS}" -eq 1 ] &&
+		DIST_INSTALL_ARGS="--skip-subprojects"
+
+	if [ -z "${DIST_PKG_NAME}" ] || [ -z "${DIST_PKG_VERSION}" ] ||
+		[ -z "${DIST_BUILD_TYPE}" ]; then
+		sh_error 'Package name, version or buildtype was not provided'
+	fi
+
+	unset short_opts
+	unset long_opts
+}
+
+generate_version_file() {
+	echo "${DIST_PKG_VERSION}" >"${MESON_PROJECT_DIST_ROOT}/.version"
+}
+
+is_vaccel() {
+	if [ "${DIST_PKG_NAME}" != "vaccel" ]; then
+		[ "${DIST_PKG_NAME#*"vaccel"}" = "${DIST_PKG_NAME}" ] &&
+			sh_error "Package name must start with 'vaccel'"
+		return 1 # false
+	fi
+	return 0 # true
+}
+
+generate_bin_pkg() {
+	bin_name="${DIST_PKG_NAME}_${DIST_PKG_VERSION}"
+	bin_tar_name="${bin_name}_$(sh_print_arch).tar.gz"
+	bin_prefix="${MESON_PROJECT_DIST_ROOT}/build/${bin_name}"
+
+	rm -rf ../"${bin_tar_name}" build
+
+	if [ -f "${DIST_DEB_PKG_FILE}" ]; then
+		mkdir -p "build/${bin_name}"
+		dpkg -x "${DIST_DEB_PKG_FILE}" "build/${bin_name}"
+	else
+		eval meson setup "${DIST_BUILD_ARGS}" \
+			--wrap-mode=nodownload \
+			--prefix="${bin_prefix}/usr" \
+			build
+		meson compile -C build
+		eval meson install "${DIST_INSTALL_ARGS}" -C build
+	fi
+
+	tar cfz ../"${bin_tar_name}" -C build "${bin_name}"
+	rm -rf build
+
+	DIST_BIN_PKG_FILE="$(dirname "${MESON_PROJECT_DIST_ROOT}")/${bin_tar_name}"
+	printf '\nCreated %s\n\n' "$DIST_BIN_PKG_FILE"
+
+	unset bin_name
+	unset bin_tar_name
+	unset bin_prefix
+}
+
+deb_check_requirements() {
+	missing_pkgs=
+
+	for p in 'build-essential' 'dh-make' 'git-buildpackage'; do
+		if [ -z "$(dpkg -l | awk "/^ii  $p/")" ]; then
+			missing_pkgs="${missing_pkgs} $p"
+		fi
+	done
+
+	if [ -n "${missing_pkgs}" ]; then
+		echo "Not building a deb package: Packages${missing_pkgs} missing"
+		unset missing_pkgs
+		return 1
+	fi
+
+	unset missing_pkgs
+	return 0
+}
+
+deb_process_rules() {
+	printf 'export DEB_LDFLAGS_MAINT_STRIP = -Wl,-Bsymbolic-functions\n' \
+		>>debian/rules
+	printf 'override_dh_auto_configure:\n\t%s' \
+		"dh_auto_configure --buildsystem=meson -- ${DIST_BUILD_ARGS}" \
+		>>debian/rules
+}
+
+deb_process_copyright() {
+	sed -i "s/Upstream-Contact.*/Upstream-Contact: ${_DIST_UPSTREAM_CONTACT}/g" \
+		debian/copyright
+	sed -i "s/Source.*/Source: $(echo "$DIST_REPO_URL" | sed 's/\//\\\//g')/g" \
+		debian/copyright
+	perl -0777 -i.bak -spe \
+		's|Copyright:.*\n(?:[ \t].*\n)*(?=License:)|Copyright:\n 2020-$year Nubificus Ltd.\n|g' \
+		-- \
+		-year="$(date +"%Y")" \
+		debian/copyright
+	sed -i -z -e "s/\n#.*[\n]*//g" debian/copyright
+}
+
+deb_process_control() {
+	sed -i 's/Homepage.*/Homepage: https:\/\/vaccel.org/g' \
+		debian/control
+	sed -i 's/Section.*/Section: libs/g' debian/control
+	sed -i -z -e \
+		's/Description.*/Description: Hardware Acceleration for Serverless Computing/g' \
+		debian/control
+	sed -i '/^#.*/d' debian/control
+	sed -i '/cmake/d' debian/control
+	if ! is_vaccel; then
+		sed -i -z -e \
+			's/\(Depends:\n.*\n\)\(Description\)/\1 vaccel,\n\2/g' \
+			debian/control
+	fi
+}
+
+deb_changelog_add_commits() {
+	gbp dch --since="$1" --ignore-branch --release \
+		--spawn-editor=never --new-version="$2" \
+		--dch-opt='-b' --dch-opt='--check-dirname-level=0' \
+		--dch-opt='-p' \
+		--git-log='--invert-grep --grep=^Signed-off-by:.*github-actions --grep=^Signed-off-by:.*dependabot --grep=^ci: --grep=^ci(.*):'
+}
+
+deb_process_changelog() {
+	sed -i '2d;3d' debian/changelog
+	tag=$(git describe --abbrev=0 --tags --match 'v[0-9]*' 2>/dev/null)
+	tag_diff=$(git describe --abbrev=8 --tags --match 'v[0-9]*' 2>/dev/null)
+	orig_commit=$(git rev-parse HEAD)
+
+	for t in $(git tag --sort=v:refname | grep 'v[0-9]*'); do
+		cur_version="$(echo "$t" | cut -c 2-)-1"
+		git checkout "$t" 1>/dev/null 2>&1
+		prev_tag=$(git describe --abbrev=0 --tags --match 'v[0-9]*' \
+			--exclude="$t" 2>/dev/null) ||
+			prev_tag=$(git rev-list --max-parents=0 HEAD | tail -n 1)
+		deb_changelog_add_commits "${prev_tag}" "${cur_version}"
+	done
+
+	if [ "${tag}" != "${tag_diff}" ]; then
+		git checkout "${orig_commit}" 1>/dev/null 2>&1
+		prev_tag=$(git describe --abbrev=0 --tags --match 'v[0-9]*' \
+			2>/dev/null) ||
+			prev_tag=$(git rev-list --max-parents=0 HEAD | tail -n 1)
+		cur_version="${DIST_PKG_VERSION}-1"
+		deb_changelog_add_commits "${prev_tag}" "${cur_version}"
+	fi
+
+	unset tag
+	unset tag_diff
+	unset orig_commit
+	unset cur_version
+	unset prev_tag
+}
+
+generate_deb_pkg() {
+	! deb_check_requirements && return 0
+
+	rm -f ../*"${DIST_PKG_VERSION}".orig.tar.xz
+	rm -rf "${MESON_PROJECT_DIST_ROOT}"/.git*
+
+	export DEBFULLNAME="$_DIST_DEBFULLNAME"
+	export DEBEMAIL="$_DIST_DEBEMAIL"
+
+	USER="$(whoami)" \
+		dh_make -s -y -c apache \
+		-p "${DIST_PKG_NAME}_${DIST_PKG_VERSION}" --createorig
+
+	# debian/rules
+	deb_process_rules
+
+	# debian/copyright
+	deb_process_copyright
+
+	# debian/control
+	deb_process_control
+
+	# debian/changelog
+	echo 'Generating changelog'
+	cp -r "$MESON_PROJECT_SOURCE_ROOT"/.git* ./
+	deb_process_changelog
+	rm -rf "$MESON_PROJECT_DIST_ROOT"/.git*
+
+	echo 'Building package'
+	rm -rf debian/*.ex debian/*.EX debian/*.docs debian/README*
+	dpkg-buildpackage -us -uc
+	rm -rf obj-* debian
+
+	deb_dir="$(dirname "$MESON_PROJECT_DIST_ROOT")"
+	deb_base_name="${DIST_PKG_NAME}_${DIST_PKG_VERSION}"
+	DIST_DEB_PKG_FILE="$(ls "$deb_dir"/"$deb_base_name"*.deb)"
+	printf '\nCreated %s\n\n' "$DIST_DEB_PKG_FILE"
+
+	unset DEBFULLNAME
+	unset DEBEMAIL
+	unset deb_dir
+	unset deb_name
+}

--- a/dist.sh
+++ b/dist.sh
@@ -3,276 +3,35 @@
 
 set -e
 
-_SH_SCRIPTS_DIR=$(cd -- "$(dirname -- "$0")" >/dev/null && pwd -P)
-# shellcheck disable=SC2034
-SH_SCRIPT_NAME=$(basename "$0")
+_SH_SCRIPTS_DIR="$(cd -- "$(dirname -- "$0")" >/dev/null && pwd -P)"
+SH_SCRIPTS_DIR="${SH_SCRIPTS_DIR:-"$_SH_SCRIPTS_DIR"}"
 # shellcheck source=/dev/null
-. "${_SH_SCRIPTS_DIR}/_sh-common.sh"
-
-REPO_URL=$(git remote get-url origin |
-	sed 's/git@github.com:\(.*\)\.git/https:\/\/github.com\/\1/g')
-UPSTREAM_CONTACT='vaccel@nubificus.co.uk'
-DEBFULLNAME='Kostis Papazafeiropoulos'
-export DEBFULLNAME
-DEBEMAIL='papazof@nubificus.co.uk'
-export DEBEMAIL
-
-parse_args() {
-	short_opts='n:v:t:a:'
-	long_opts='pkg-name:,pkg-version:,build-type:,build-arg:,skip-subprojects,skip-deb'
-
-	if ! getopt=$(getopt -o "${short_opts}" --long "${long_opts}" \
-		-n "${SCRIPT_NAME}" -- "$@"); then
-		sh_error 'Failed to parse args'
-	fi
-
-	eval set -- "$getopt"
-
-	build_args=
-	install_args=
-	skip_deb=0
-	skip_subprojects=0
-	while true; do
-		case "$1" in
-		'-n' | '--pkg-name')
-			# Package name
-			[ -z "$2" ] &&
-				sh_error "'$1' requires a non-empty string"
-			pkg_name="$2"
-			shift 2
-			;;
-		'-v' | '--pkg-version')
-			# Package version
-			[ -z "$2" ] &&
-				sh_error "'$1' requires a non-empty string"
-			pkg_version="$2"
-			shift 2
-			;;
-		'-t' | '--build-type')
-			# Build type
-			[ -z "$2" ] &&
-				sh_error "'$1' requires a non-empty string"
-			build_type="$2"
-			shift 2
-			;;
-		'-a' | '--build-arg')
-			# Build args
-			arg=$(echo "$2" | cut -d'=' -f1)
-			value=$(echo "$2" | cut -d'=' -f2-)
-			[ -z "${arg}" ] || [ -z "${value}" ] &&
-				sh_error "'$1' requires a string of the form 'arg=value'"
-			build_args="${build_args} -D${arg}=${value}"
-			unset arg
-			unset value
-			shift 2
-			;;
-		'--skip-subprojects')
-			# Skip subproject installation
-			skip_subprojects=1
-			shift
-			;;
-		'--skip-deb')
-			# Skip deb generation
-			skip_deb=1
-			shift
-			;;
-		--)
-			shift
-			break
-			;;
-		*)
-			sh_error 'Internal error parsing args'
-			;;
-		esac
-	done
-
-	build_args="--buildtype=${build_type} ${build_args}"
-	[ "${skip_subprojects}" -eq 1 ] && install_args="--skip-subprojects"
-
-	if [ -z "${pkg_name}" ] || [ -z "${pkg_version}" ] ||
-		[ -z "${build_type}" ]; then
-		sh_error 'Package name, version or buildtype was not provided'
-	fi
-}
-
-generate_version_file() {
-	echo "${pkg_version}" >"${MESON_DIST_ROOT}/.version"
-}
-
-is_vaccel() {
-	if [ "${pkg_name}" != "vaccel" ]; then
-		[ "${pkg_name#*"vaccel"}" = "${pkg_name}" ] &&
-			sh_error "Package name must start with 'vaccel'"
-		return 1 # false
-	fi
-	return 0 # true
-}
-
-generate_bin_pkg() {
-	bin_name="${pkg_name}_${pkg_version}"
-	bin_tar_name="${bin_name}_$(sh_print_arch).tar.gz"
-	bin_prefix="${MESON_DIST_ROOT}/build/${bin_name}"
-
-	rm -rf ../"${bin_tar_name}" build
-
-	if [ -f "${deb_pkg_file}" ]; then
-		mkdir -p "build/${bin_name}"
-		dpkg -x "${deb_pkg_file}" "build/${bin_name}"
-	else
-		eval meson setup "${build_args}" \
-			--wrap-mode=nodownload \
-			--prefix="${bin_prefix}/usr" \
-			build
-		meson compile -C build
-		eval meson install "${install_args}" -C build
-	fi
-
-	tar cfz ../"${bin_tar_name}" -C build "${bin_name}"
-	rm -rf build
-
-	printf "\n%s\n\n" \
-		"Created $(dirname "${MESON_DIST_ROOT}")/${bin_tar_name}"
-}
-
-deb_check_requirements() {
-	missing_pkgs=
-	for p in 'build-essential' 'dh-make' 'git-buildpackage'; do
-		if [ -z "$(dpkg -l | awk "/^ii  $p/")" ]; then
-			missing_pkgs="${missing_pkgs} $p"
-		fi
-	done
-	if [ -n "${missing_pkgs}" ]; then
-		echo "Not building a deb package: Packages${missing_pkgs} missing"
-		return 1
-	fi
-	return 0
-}
-
-deb_process_rules() {
-	printf "%s\n" \
-		'export DEB_LDFLAGS_MAINT_STRIP = -Wl,-Bsymbolic-functions' \
-		>>debian/rules
-	printf "%s\n\t%s" 'override_dh_auto_configure:' \
-		"dh_auto_configure --buildsystem=meson -- ${build_args}" \
-		>>debian/rules
-}
-
-deb_process_copyright() {
-	sed -i "s/Upstream-Contact.*/Upstream-Contact: ${UPSTREAM_CONTACT}/g" \
-		debian/copyright
-	sed -i "s/Source.*/Source: $(echo "$REPO_URL" | sed 's/\//\\\//g')/g" \
-		debian/copyright
-	perl -0777 -i.bak -spe \
-		's|Copyright:.*\n(?:[ \t].*\n)*(?=License:)|Copyright:\n 2020-$year Nubificus Ltd.\n|g' \
-		-- \
-		-year="$(date +"%Y")" \
-		debian/copyright
-	sed -i -z -e "s/\n#.*[\n]*//g" debian/copyright
-}
-
-deb_process_control() {
-	sed -i 's/Homepage.*/Homepage: https:\/\/vaccel.org/g' \
-		debian/control
-	sed -i 's/Section.*/Section: libs/g' debian/control
-	sed -i -z -e \
-		's/Description.*/Description: Hardware Acceleration for Serverless Computing/g' \
-		debian/control
-	sed -i '/^#.*/d' debian/control
-	sed -i '/cmake/d' debian/control
-	if ! is_vaccel; then
-		sed -i -z -e \
-			's/\(Depends:\n.*\n\)\(Description\)/\1 vaccel,\n\2/g' \
-			debian/control
-	fi
-}
-
-deb_changelog_add_commits() {
-	gbp dch --since="$1" --ignore-branch --release \
-		--spawn-editor=never --new-version="$2" \
-		--dch-opt='-b' --dch-opt='--check-dirname-level=0' \
-		--dch-opt='-p' \
-		--git-log='--invert-grep --grep=^Signed-off-by:.*github-actions --grep=^Signed-off-by:.*dependabot --grep=^ci: --grep=^ci(.*):'
-}
-
-deb_process_changelog() {
-	sed -i '2d;3d' debian/changelog
-	tag=$(git describe --abbrev=0 --tags --match 'v[0-9]*' 2>/dev/null)
-	tag_diff=$(git describe --abbrev=8 --tags --match 'v[0-9]*' 2>/dev/null)
-	orig_commit=$(git rev-parse HEAD)
-	for t in $(git tag --sort=v:refname | grep 'v[0-9]*'); do
-		cur_version="$(echo "$t" | cut -c 2-)-1"
-		git checkout "$t" 1>/dev/null 2>&1
-		prev_tag=$(git describe --abbrev=0 --tags --match 'v[0-9]*' \
-			--exclude="$t" 2>/dev/null) ||
-			prev_tag=$(git rev-list --max-parents=0 HEAD | tail -n 1)
-		deb_changelog_add_commits "${prev_tag}" "${cur_version}"
-	done
-	if [ "${tag}" != "${tag_diff}" ]; then
-		git checkout "${orig_commit}" 1>/dev/null 2>&1
-		prev_tag=$(git describe --abbrev=0 --tags --match 'v[0-9]*' \
-			2>/dev/null) ||
-			prev_tag=$(git rev-list --max-parents=0 HEAD | tail -n 1)
-		cur_version="${pkg_version}-1"
-		deb_changelog_add_commits "${prev_tag}" "${cur_version}"
-	fi
-	unset tag
-	unset tag_diff
-	unset orig_commit
-}
-
-generate_deb_pkg() {
-	! deb_check_requirements && return 0
-
-	rm -f ../*"${pkg_version}".orig.tar.xz
-	rm -rf "${MESON_DIST_ROOT}"/.git*
-
-	USER="$(whoami)" \
-		dh_make -s -y -c apache \
-		-p "${pkg_name}_${pkg_version}" --createorig
-
-	# debian/rules
-	deb_process_rules
-
-	# debian/copyright
-	deb_process_copyright
-
-	# debian/control
-	deb_process_control
-
-	# debian/changelog
-	echo 'Generating changelog'
-	cp -r "${MESON_SOURCE_ROOT}"/.git* ./
-	deb_process_changelog
-	rm -rf "${MESON_DIST_ROOT}"/.git*
-
-	echo 'Building package'
-	rm -rf debian/*.ex debian/*.EX debian/*.docs debian/README*
-	dpkg-buildpackage -us -uc
-	rm -rf obj-* debian
-
-	deb_pkg_file="$(ls "$(dirname "${MESON_DIST_ROOT}")"/"${pkg_name}_${pkg_version}"*.deb)"
-	printf "\n%s\n\n" "Created ${deb_pkg_file}"
-}
+. "${SH_SCRIPTS_DIR}/dist-common.sh"
 
 main() {
 	parse_args "$@"
 
-	printf "Package    : %s\n" "${pkg_name}"
-	printf "Version    : %s\n" "${pkg_version}"
-	printf "Repo URL   : %s\n" "${REPO_URL}"
-	printf "Build type : %s\n" "${build_type}"
-	printf "Meson args : %s\n\n" "${build_args}"
+	printf 'Package    : %s\n' "$DIST_PKG_NAME"
+	printf 'Version    : %s\n' "$DIST_PKG_VERSION"
+	printf 'Repo URL   : %s\n' "$DIST_REPO_URL"
+	printf 'Build type : %s\n' "$DIST_BUILD_TYPE"
+	printf 'Meson args : %s\n\n' "$DIST_BUILD_ARGS"
 
+	printf 'Generating version file\n'
 	generate_version_file
 
-	cd "${MESON_DIST_ROOT}" || sh_error "Could not change to ${MESON_DIST_ROOT}"
+	if [ "$DIST_VERSION_ONLY" -eq 1 ]; then
+		return
+	fi
 
-	if [ "${skip_deb}" -eq 0 ]; then
-		printf "%s\n\n" 'Generating deb package'
+	cd "$MESON_DIST_ROOT" || sh_error "Could not change to ${MESON_DIST_ROOT}"
+
+	if [ "$DIST_SKIP_DEB" -eq 0 ]; then
+		printf 'Generating deb package\n\n'
 		generate_deb_pkg
 	fi
 
-	printf "%s\n\n" 'Generating binary distribution'
+	printf 'Generating binary distribution\n\n'
 	generate_bin_pkg
 }
 

--- a/dist.sh
+++ b/dist.sh
@@ -114,9 +114,19 @@ generate_bin_pkg() {
 	bin_prefix="${MESON_DIST_ROOT}/build/${bin_name}"
 
 	rm -rf ../"${bin_tar_name}" build
-	eval meson setup "${build_args}" --prefix="${bin_prefix}/usr" build
-	meson compile -C build
-	eval meson install "${install_args}" -C build
+
+	if [ -f "${deb_pkg_file}" ]; then
+		mkdir -p "build/${bin_name}"
+		dpkg -x "${deb_pkg_file}" "build/${bin_name}"
+	else
+		eval meson setup "${build_args}" \
+			--wrap-mode=nodownload \
+			--prefix="${bin_prefix}/usr" \
+			build
+		meson compile -C build
+		eval meson install "${install_args}" -C build
+	fi
+
 	tar cfz ../"${bin_tar_name}" -C build "${bin_name}"
 	rm -rf build
 
@@ -132,7 +142,7 @@ deb_check_requirements() {
 		fi
 	done
 	if [ -n "${missing_pkgs}" ]; then
-		echo "Not building a deb package: Packages ${missing_pkgs} missing"
+		echo "Not building a deb package: Packages${missing_pkgs} missing"
 		return 1
 	fi
 	return 0
@@ -240,8 +250,8 @@ generate_deb_pkg() {
 	dpkg-buildpackage -us -uc
 	rm -rf obj-* debian
 
-	printf "\n%s\n\n" \
-		"Created $(ls "$(dirname "${MESON_DIST_ROOT}")"/"${pkg_name}_${pkg_version}"*.deb)"
+	deb_pkg_file="$(ls "$(dirname "${MESON_DIST_ROOT}")"/"${pkg_name}_${pkg_version}"*.deb)"
+	printf "\n%s\n\n" "Created ${deb_pkg_file}"
 }
 
 main() {
@@ -257,13 +267,13 @@ main() {
 
 	cd "${MESON_DIST_ROOT}" || sh_error "Could not change to ${MESON_DIST_ROOT}"
 
-	printf "%s\n\n" 'Generating binary distribution'
-	generate_bin_pkg
-
 	if [ "${skip_deb}" -eq 0 ]; then
 		printf "%s\n\n" 'Generating deb package'
 		generate_deb_pkg
 	fi
+
+	printf "%s\n\n" 'Generating binary distribution'
+	generate_bin_pkg
 }
 
 main "$@"

--- a/dist.sh
+++ b/dist.sh
@@ -11,8 +11,7 @@ SH_SCRIPT_NAME=$(basename "$0")
 
 REPO_URL=$(git remote get-url origin |
 	sed 's/git@github.com:\(.*\)\.git/https:\/\/github.com\/\1/g')
-UPFULLNAME='Anastassios Nanos'
-UPEMAIL='ananos@nubificus.co.uk'
+UPSTREAM_CONTACT='vaccel@nubificus.co.uk'
 DEBFULLNAME='Kostis Papazafeiropoulos'
 export DEBFULLNAME
 DEBEMAIL='papazof@nubificus.co.uk'
@@ -149,12 +148,14 @@ deb_process_rules() {
 }
 
 deb_process_copyright() {
-	sed -i "s/Upstream-Contact.*/Upstream-Contact: ${UPFULLNAME} <${UPEMAIL}>/g" \
+	sed -i "s/Upstream-Contact.*/Upstream-Contact: ${UPSTREAM_CONTACT}/g" \
 		debian/copyright
 	sed -i "s/Source.*/Source: $(echo "$REPO_URL" | sed 's/\//\\\//g')/g" \
 		debian/copyright
-	sed -i -z -e \
-		"s/\(Copyright:\)\n[^\n]\+[\n]*[^\n]*\n\(License\)/\1 2020-$(date +"%Y") Nubificus LTD <info@nubificus.co.uk>\n\2/g" \
+	perl -0777 -i.bak -spe \
+		's|Copyright:.*\n(?:[ \t].*\n)*(?=License:)|Copyright:\n 2020-$year Nubificus Ltd.\n|g' \
+		-- \
+		-year="$(date +"%Y")" \
 		debian/copyright
 	sed -i -z -e "s/\n#.*[\n]*//g" debian/copyright
 }

--- a/dist.sh
+++ b/dist.sh
@@ -110,8 +110,8 @@ is_vaccel() {
 }
 
 generate_bin_pkg() {
-	bin_name="${pkg_name}-${pkg_version}"
-	bin_tar_name="${bin_name}-bin.tar.gz"
+	bin_name="${pkg_name}_${pkg_version}"
+	bin_tar_name="${bin_name}_$(sh_print_arch).tar.gz"
 	bin_prefix="${MESON_DIST_ROOT}/build/${bin_name}"
 
 	rm -rf ../"${bin_tar_name}" build

--- a/generate-version.sh
+++ b/generate-version.sh
@@ -3,37 +3,149 @@
 
 set -e
 
-SRC_DIR=$1
-DEFAULT_VERSION="v0.0.0"
+_SH_SCRIPTS_DIR="$(cd -- "$(dirname -- "$0")" >/dev/null && pwd -P)"
+SH_SCRIPTS_DIR="${SH_SCRIPTS_DIR:-"$_SH_SCRIPTS_DIR"}"
+# shellcheck source=/dev/null
+. "${SH_SCRIPTS_DIR}/_sh-common.sh"
 
-[ -n "${SRC_DIR}" ] || SRC_DIR="."
-
-if [ -f "${SRC_DIR}/.version" ]; then
-	cat "${SRC_DIR}/.version"
-	exit 0
+if [ -n "$MESON_SUBDIR" ]; then
+	_MESON_SOURCE_DIR="${MESON_SOURCE_ROOT}/${MESON_SUBDIR}"
+else
+	_MESON_SOURCE_DIR="$MESON_SOURCE_ROOT"
 fi
 
-if [ ! -d "${SRC_DIR}/.git" ]; then
-	echo ${DEFAULT_VERSION}
-	exit 1
-fi
+SOURCE_DIR_DEFAULT="${_MESON_SOURCE_DIR:-.}"
+VERSION_DEFAULT='v0.0.1'
 
-VERSION=$(git describe --abbrev=8 --tags --match "v[0-9]*" 2>/dev/null || echo)
+parse_args() {
+	short_opts='s:,w,o:'
+	long_opts='source-dir:,write,output-dir:,no-dirty'
 
-if [ -z "${VERSION}" ]; then
-	SHA=$(git describe --abbrev=8 --always 2>/dev/null)
-	COMMITS=$(git log --oneline | wc -l 2>/dev/null)
-	VERSION="v0.0.0-${COMMITS}-g${SHA}"
-fi
-
-DIRTY=$(git diff --quiet || echo '-dirty')
-for i in "$@"; do
-	if [ "$i" = "--no-dirty" ]; then
-		DIRTY=""
-		break
+	if ! getopt=$(getopt -o "$short_opts" --long "$long_opts" \
+		-n "$SH_SCRIPT_NAME" -- "$@"); then
+		sh_error 'Failed to parse args'
 	fi
-done
 
-VERSION=$(echo "${VERSION}${DIRTY}" | sed -e 's/-g/-/' | cut -c 2-)
+	eval set -- "$getopt"
 
-echo "${VERSION}"
+	write=0
+	output_dir=
+	no_dirty=0
+	while true; do
+		case "$1" in
+		'-s' | '--source-dir')
+			# Source directory
+			[ -z "$2" ] &&
+				sh_error "'$1' requires a non-empty string"
+			source_dir="$2"
+			shift 2
+			;;
+		'-w' | '--write')
+			# Write to file
+			write=1
+			shift 1
+			;;
+		'-o' | '--output-dir')
+			# Write to file in output directory
+			[ ! -d "$(dirname "$2")" ] &&
+				sh_error "'$1' directory does not exist"
+			write=1
+			output_dir="$2"
+			shift 2
+			;;
+		'--no-dirty')
+			# Do not append '-dirty' metadata
+			no_dirty=1
+			shift 1
+			;;
+		--)
+			shift
+			break
+			;;
+		*)
+			sh_error 'Internal error parsing args'
+			;;
+		esac
+	done
+
+	source_dir="${source_dir:-"$SOURCE_DIR_DEFAULT"}"
+
+	unset short_opts
+	unset long_opts
+}
+
+generate_version() {
+	dirty=
+
+	if git -C "$source_dir" status >/dev/null 2>&1 &&
+		[ -e "${source_dir}/.git" ]; then
+		if git -C "$source_dir" describe --tags --match "v[0-9]*" \
+			--exact-match HEAD >/dev/null 2>&1; then
+			version=$(git -C "$source_dir" tag --points-at HEAD |
+				grep -E '^v[0-9]' |
+				awk '{
+					tag = $0
+					if (match($0, /\+[^,]*/)) {
+					  base = substr($0, 1, RSTART-1)
+					  build = substr($0, RSTART+1, RLENGTH-1)
+					} else {
+					  base = $0
+					  build = ""
+					}
+					print base "," build "," tag
+				}' |
+				sort -V -t',' -k1,1 -k2,2 |
+				tail -1 |
+				cut -d',' -f3)
+		else
+			version=$(git -C "$source_dir" describe \
+				--abbrev=8 --tags --match "v[0-9]*" 2>/dev/null |
+				sed 's/+[^-]*//' ||
+				true)
+		fi
+
+		if [ -z "$version" ]; then
+			sha=$(git -C "$source_dir" describe --abbrev=8 --always)
+			commits=$(git -C "$source_dir" log --oneline | wc -l)
+			version="v0.0.1-${commits}-${sha}"
+
+			unset sha
+			unset commits
+		fi
+
+		if [ "$no_dirty" -eq 0 ]; then
+			dirty=$(git -C "$source_dir" diff --quiet ||
+				echo '-dirty')
+		fi
+	fi
+
+	version=$(echo "${version:-"$VERSION_DEFAULT"}${dirty}" |
+		sed -e 's/-g/-/' | cut -c 2-)
+
+	unset dirty
+}
+
+main() {
+	parse_args "$@"
+
+	version_file="${source_dir}/.version"
+	if [ -f "$version_file" ]; then
+		cat "$version_file"
+		exit 0
+	fi
+
+	generate_version
+
+	if [ "$write" -eq 0 ]; then
+		echo "$version"
+		exit 0
+	fi
+
+	if [ -z "$output_dir" ]; then
+		echo "$version" >"$version_file"
+	else
+		echo "$version" >"${output_dir}/.version"
+	fi
+}
+
+main "$@"

--- a/sh-common.sh
+++ b/sh-common.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+SH_SCRIPT_NAME="${SH_SCRIPT_NAME:-"$(basename "$0")"}"
+
+sh_print_arch() {
+	arch="$(uname -m | tr ' ' '_' | tr '/' '-')"
+	if [ "$(getconf LONG_BIT)" -eq 32 ]; then
+		arch="$(printf '%s' "$arch" | sed 's/x86_64/i686/')"
+		arch="$(printf '%s' "$arch" | sed 's/aarch64/armv7l/')"
+	fi
+	printf '%s\n' "$arch"
+	unset arch
+}
+
+sh_log_error() {
+	error="${1:-'Unknown error'}"
+	code="${2:-1}"
+	printf '%s: %s [error %s]\n' \
+		"$SH_SCRIPT_NAME" "$error" "$code" \
+		>&2
+	unset error
+	unset code
+}
+
+sh_error() {
+	error_code="${2:-1}"
+	sh_log_error "$1" "$error_code"
+	exit "$error_code"
+}


### PR DESCRIPTION
Include architecture in artifact names and improve dist, versioning, and common script reusability and correctness:
- Include system architecture in binary artifact names
- Re-package built files from the debian package in the binary artifact instead of rebuilding the project when the .deb build is enabled
- Improve `generate-version.sh` argument parsing and tag handling
- Split dist functions into a reusable `dist-common.sh`
- Make `sh-common.sh` part of the public interface
- Fix debian copyright file generation