### PR TITLE
ci: Improve workflows and add auto-merge support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,15 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      # Workaround for https://github.com/dependabot/dependabot-core/issues/6345
+      - "/.github/actions/*"
     schedule:
       interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     commit-message:
       prefix: "ci(deps)"

--- a/.github/workflows/pr-trailers.yml
+++ b/.github/workflows/pr-trailers.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 name: Add Git Trailers to PR commits
 
 on:

--- a/.github/workflows/pr-trailers.yml
+++ b/.github/workflows/pr-trailers.yml
@@ -3,14 +3,29 @@ name: Add Git Trailers to PR commits
 on:
   pull_request_review:
     types: [submitted]
+  pull_request:
+    types: [synchronize, labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  git-trailers:
+  check-pr-status:
+    name: Check PR status
+    if: ${{ github.event.pull_request.base.ref == 'main' }}
+    uses: nubificus/vaccel/.github/workflows/check-pr-status.yml@main
+    with:
+      pr-number: >-
+        ${{ github.event.pull_request_review.pull_request.number ||
+          github.event.pull_request.number }}
+    secrets: inherit
+
+  add-git-trailers:
+    needs: check-pr-status
     name: Add Git Trailers to PR commits
-    if: ${{ github.event.pull_request.base.ref == 'main' && github.event.review.state == 'approved' }}
+    if: >-
+      ${{ github.event.pull_request.base.ref == 'main' &&
+        needs.check-pr-status.outputs.is-approved == 'true' }}
     uses: nubificus/vaccel/.github/workflows/add-git-trailers.yml@main
     secrets: inherit

--- a/.github/workflows/pr-trailers.yml
+++ b/.github/workflows/pr-trailers.yml
@@ -7,13 +7,16 @@ on:
     types: [synchronize, labeled]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: >-
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+
+permissions: read-all
 
 jobs:
   check-pr-status:
     name: Check PR status
-    if: ${{ github.event.pull_request.base.ref == 'main' }}
+    if: github.event.pull_request.base.ref == 'main'
     uses: nubificus/vaccel/.github/workflows/check-pr-status.yml@main
     with:
       pr-number: >-
@@ -25,7 +28,7 @@ jobs:
     needs: check-pr-status
     name: Add Git Trailers to PR commits
     if: >-
-      ${{ github.event.pull_request.base.ref == 'main' &&
-        needs.check-pr-status.outputs.is-approved == 'true' }}
+      github.event.pull_request.base.ref == 'main' &&
+      needs.check-pr-status.outputs.is-approved == 'true'
     uses: nubificus/vaccel/.github/workflows/add-git-trailers.yml@main
     secrets: inherit

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -12,22 +12,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-pr-status:
+    name: Check PR status
+    uses: nubificus/vaccel/.github/workflows/check-pr-status.yml@main
+    secrets: inherit
+
   validate-files-and-commits:
+    needs: check-pr-status
     name: Validate Files and Commits
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
+    if: ${{ needs.check-pr-status.outputs.expects-checks == 'true' }}
     uses: nubificus/vaccel/.github/workflows/validate-files-and-commits.yml@main
     secrets: inherit
 
   validate-code:
+    needs: check-pr-status
     name: Validate Code
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
+    if: ${{ needs.check-pr-status.outputs.expects-checks == 'true' }}
     uses: ./.github/workflows/validate-code.yml
     secrets: inherit
 
   # Dummy job for setting required checks
   jobs-completed:
-    needs: [validate-files-and-commits, validate-code]
+    needs: [check-pr-status, validate-files-and-commits, validate-code]
     name: Jobs Completed
+    if: >-
+      ${{ always() &&
+        (needs.check-pr-status.outputs.is-approved == 'true' ||
+          (needs.check-pr-status.outputs.expects-checks == 'true' &&
+            !contains(needs.*.result, 'failure') &&
+            !contains(needs.*.result, 'cancelled'))) }}
     runs-on: base-2204-amd64
     steps:
       - run: exit 0

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -8,8 +8,11 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: >-
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+
+permissions: read-all
 
 jobs:
   check-pr-status:
@@ -20,14 +23,14 @@ jobs:
   validate-files-and-commits:
     needs: check-pr-status
     name: Validate Files and Commits
-    if: ${{ needs.check-pr-status.outputs.expects-checks == 'true' }}
+    if: needs.check-pr-status.outputs.expects-checks == 'true'
     uses: nubificus/vaccel/.github/workflows/validate-files-and-commits.yml@main
     secrets: inherit
 
   validate-code:
     needs: check-pr-status
     name: Validate Code
-    if: ${{ needs.check-pr-status.outputs.expects-checks == 'true' }}
+    if: needs.check-pr-status.outputs.expects-checks == 'true'
     uses: ./.github/workflows/validate-code.yml
     secrets: inherit
 
@@ -36,11 +39,11 @@ jobs:
     needs: [check-pr-status, validate-files-and-commits, validate-code]
     name: Jobs Completed
     if: >-
-      ${{ always() &&
-        (needs.check-pr-status.outputs.is-approved == 'true' ||
-          (needs.check-pr-status.outputs.expects-checks == 'true' &&
-            !contains(needs.*.result, 'failure') &&
-            !contains(needs.*.result, 'cancelled'))) }}
+      always() &&
+      (needs.check-pr-status.outputs.is-approved == 'true' ||
+        (needs.check-pr-status.outputs.expects-checks == 'true' &&
+          !contains(needs.*.result, 'failure') &&
+          !contains(needs.*.result, 'cancelled')))
     runs-on: base-2204-amd64
     steps:
       - run: exit 0

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 name: Verify
 
 on:

--- a/.github/workflows/schedule-update-notice.yml
+++ b/.github/workflows/schedule-update-notice.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 name: Update NOTICE
 
 on:

--- a/.github/workflows/schedule-update-notice.yml
+++ b/.github/workflows/schedule-update-notice.yml
@@ -1,0 +1,18 @@
+name: Update NOTICE
+
+on:
+  schedule:
+    # 00:05 UTC on January 1st every year
+    - cron: '5 0 1 1 *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+permissions: read-all
+
+jobs:
+  update-notice:
+    name: Update NOTICE Year
+    uses: nubificus/vaccel/.github/workflows/update-notice-year.yml@main
+    secrets: inherit

--- a/.github/workflows/validate-code.yml
+++ b/.github/workflows/validate-code.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 name: Validate Source Code
 
 on:

--- a/.github/workflows/validate-code.yml
+++ b/.github/workflows/validate-code.yml
@@ -6,7 +6,7 @@ on:
       actions-repo:
         type: string
         default: 'nubificus/vaccel'
-      actions-rev:
+      actions-ref:
         type: string
         default: 'main'
       runner:
@@ -29,13 +29,17 @@ on:
       AWS_SECRET_ACCESS_KEY:
         required: false
 
+permissions: read-all
+
 env:
-  ACTIONS_REV: ${{ (github.repository != inputs.actions-repo) && inputs.actions-rev || '' }}
+  ACTIONS_REF: >-
+    ${{ github.repository != inputs.actions-repo && inputs.actions-ref || '' }}
 
 jobs:
   linter-super-linter:
     name: Lint Python/Shell/GHActions/Markdown/YAML/JS
-    runs-on: ${{ format('{0}-{1}', join(fromJSON(inputs.runner), '-'), matrix.arch) }}
+    runs-on: >-
+      ${{ format('{0}-{1}', join(fromJSON(inputs.runner), '-'), matrix.arch) }}
     strategy:
       matrix:
         arch: ["${{ fromJSON(inputs.runner-archs) }}"]
@@ -69,7 +73,7 @@ jobs:
         with:
           sparse-checkout: .github
           repository: ${{ inputs.actions-repo }}
-          ref: ${{ env.ACTIONS_REV }}
+          ref: ${{ env.ACTIONS_REF }}
           token: ${{ steps.generate-init-token.outputs.token || github.token }}
 
       - name: Initialize workspace

--- a/.github/workflows/validate-code.yml
+++ b/.github/workflows/validate-code.yml
@@ -22,7 +22,7 @@ on:
         type: string
         default: 'auto_features=enabled'
     secrets:
-      GIT_CLONE_PAT:
+      VACCEL_BOT_PRIVATE_KEY:
         required: false
       AWS_ACCESS_KEY:
         required: false
@@ -40,31 +40,62 @@ jobs:
       matrix:
         arch: ["${{ fromJSON(inputs.runner-archs) }}"]
       fail-fast: false
-    permissions:
-      contents: read
-      packages: read
-      statuses: write
     steps:
+      - name: Parse repository names
+        id: parse-repos
+        env:
+          ACTIONS_REPO: ${{ inputs.actions-repo }}
+        run: |
+          {
+            echo "repo-name=$(basename "$GITHUB_REPOSITORY")"
+            echo "actions-repo-name=$(basename "$ACTIONS_REPO")"
+          } >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Generate initialization vaccel-bot token
+        id: generate-init-token
+        if: vars.VACCEL_BOT_CLIENT_ID
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.VACCEL_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.VACCEL_BOT_PRIVATE_KEY }}
+          repositories: |
+            ${{ steps.parse-repos.outputs.repo-name }}
+            ${{ steps.parse-repos.outputs.actions-repo-name }}
+          permission-contents: read
+
       - name: Checkout .github directory
         uses: actions/checkout@v5
         with:
           sparse-checkout: .github
           repository: ${{ inputs.actions-repo }}
           ref: ${{ env.ACTIONS_REV }}
+          token: ${{ steps.generate-init-token.outputs.token || github.token }}
 
       - name: Initialize workspace
         uses: ./.github/actions/initialize-workspace
         with:
           fetch-depth: 0
           remote-actions-repo: ${{ inputs.actions-repo }}
-          token: ${{ secrets.GIT_CLONE_PAT || github.token }}
+          token: ${{ steps.generate-init-token.outputs.token || github.token }}
+
+      - name: Generate linter vaccel-bot token
+        id: generate-linter-token
+        if: vars.VACCEL_BOT_CLIENT_ID
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.VACCEL_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.VACCEL_BOT_PRIVATE_KEY }}
+          permission-contents: read
+          permission-packages: read
+          permission-statuses: write
 
       - name: Run super-linter
         uses: super-linter/super-linter@v8
         env:
-          DEFAULT_BRANCH: main
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ENABLE_GITHUB_ACTIONS_STEP_SUMMARY: false
+          GITHUB_TOKEN: >-
+            ${{ steps.generate-linter-token.outputs.token || github.token }}
+          ENABLE_GITHUB_PULL_REQUEST_SUMMARY_COMMENT: false
           VALIDATE_ALL_CODEBASE: true
           VALIDATE_PYTHON_RUFF: true
           VALIDATE_BASH: true


### PR DESCRIPTION
Improve CI workflows and add GitHub auto-merge support:
- Update PR workflows based on nubificus/vaccel#208 to improve required checks and support GitHub auto-merge
- Replace the long-lived PAT with short-lived `vaccel-bot` tokens, scoped per step
- Automate the annual NOTICE copyright year bump via a scheduled workflow
- General CI refactoring: group dependabot updates for GitHub Actions, add SPDX headers, tighten default permissions and clean up YAML style